### PR TITLE
Add NuGet publish workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    name: Publish NuGet packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed for MinVer
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: dotnet restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build
+
+      - name: Push to NuGet
+        run: dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -362,8 +362,9 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
-# Claude Code session logs
+# Claude Code
 sessions/
+CLAUDE.local.md
 
 # JetBrains Rider
 .idea/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` that triggers on `v*` tag pushes
- Runs build + test, then pushes all `.nupkg` files to nuget.org
- Requires `NUGET_API_KEY` repository secret

## Setup
1. Go to [nuget.org API keys](https://www.nuget.org/account/apikeys) and create a key scoped to `Boutquin.*` packages
2. Add it as a repository secret named `NUGET_API_KEY` at Settings → Secrets → Actions

## Test plan
- [ ] Add `NUGET_API_KEY` secret to the repo
- [ ] Push a new tag (e.g., `v0.6.0-beta.2`) and verify packages appear on nuget.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)