### PR TITLE
Improve NuGet package metadata for all three packages

### DIFF
--- a/AspNetCore/Boutquin.AspNetCore.csproj
+++ b/AspNetCore/Boutquin.AspNetCore.csproj
@@ -2,7 +2,23 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>Boutquin.AspNetCore</Title>
+    <Description>ASP.NET Core middleware and module registration — RFC 7807 exception handler, modular app startup with testable assembly discovery.</Description>
+    <PackageTags>aspnetcore;middleware;exception-handler;rfc7807;problem-details;modular-monolith;dotnet;csharp;clean-architecture</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Resources\icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <!--
     InternalsVisibleTo grants the test project access to internal members.

--- a/Domain/Boutquin.Domain.csproj
+++ b/Domain/Boutquin.Domain.csproj
@@ -2,17 +2,12 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Common abstractions (entities, enums, exceptions, interfaces, types and logic) specific to a Domain layer.</Description>
-    <PackageTags>CleanArchitecture,Domain,Entities,GuardClauses,ContractDrivenDevelopment,ExtensionMethods,CustomExceptions,Serialization,Shared</PackageTags>
+    <Title>Boutquin.Domain</Title>
+    <Description>Domain-Driven Design building blocks for .NET — Entity base class, Result pattern, Guard clauses, strongly typed IDs, domain exceptions, and JSON converters.</Description>
+    <PackageTags>ddd;domain-driven-design;dotnet;csharp;entity;result-pattern;guard-clauses;strongly-typed-id;clean-architecture;domain-exceptions</PackageTags>
     <PackageReleaseNotes>See CHANGELOG.md for release notes.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
-    <RepositoryUrl>https://github.com/boutquin/Boutquin.Domain</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/users/boutquin/projects/1/</PackageProjectUrl>
-    <Title>Common abstractions specific to a Domain layer.</Title>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Validation/Boutquin.Validation.csproj
+++ b/Validation/Boutquin.Validation.csproj
@@ -2,7 +2,23 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>Boutquin.Validation</Title>
+    <Description>FluentValidation integration for Boutquin.Domain — ValidationException with structured error details for RFC 7807 ProblemDetails responses.</Description>
+    <PackageTags>fluentvalidation;validation;dotnet;csharp;clean-architecture;domain-driven-design;problem-details</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Resources\icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />


### PR DESCRIPTION
## Summary
- Add Description, Title, PackageTags, PackageReadmeFile, and PackageIcon to AspNetCore and Validation csprojs (were missing — only Domain had them)
- Remove duplicate license/repo/URL fields from Domain csproj that are already inherited from Directory.Build.props
- Remove stale `PackageProjectUrl` pointing to a GitHub Projects board
- Pack `README.md` and `icon.png` into all three NuGet packages (fixes "Readme missing" warning)
- Updated GitHub repo: description, homepage → nuget.org, added 10 discovery topics (dotnet, csharp, ddd, clean-architecture, etc.)

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test` — 308 passed
- [x] All three `.nupkg` files generated with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)