### PR TITLE
v0.7.0 — Remove MediatR dependency, add ErrorType/Result extensions, align repo scaffolding

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -36,5 +36,12 @@ jobs:
       - name: dotnet test with coverage
         run: dotnet test --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
 
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+        if: always()
+
       - name: dotnet format
         run: dotnet format -v detailed --verify-no-changes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,186 @@
+# Architecture
+
+This document explains how the components in Boutquin.Domain fit together. For a feature overview, see [README.md](README.md).
+
+## Layers
+
+The solution contains three independently-packaged libraries plus a test project:
+
+```
+Domain/        Core DDD building blocks (zero external dependencies)
+Validation/    FluentValidation integration (depends on Domain)
+AspNetCore/    Middleware and module system (depends on Domain + Validation)
+UnitTests/     xUnit tests (depends on all three)
+```
+
+Domain has zero external dependencies. Validation depends only on Domain and FluentValidation. AspNetCore depends on Domain, Validation, and `Microsoft.AspNetCore.App`. Tests depend on all three.
+
+## Core Abstractions
+
+### Entity & Identity
+
+```
+IEntity
+  └─ Entity<TEntityId>          Identity-based equality, domain event buffering
+       │
+       └─ StronglyTypedId<T>    Wraps primitives as domain-specific IDs
+```
+
+**Why identity-based equality?** Domain entities are identified by their ID, not their properties. Two `Order` objects with the same `OrderId` are the same order, regardless of other field values. `Entity<TEntityId>` enforces this by using only `Id` in `Equals`/`GetHashCode`. Transient entities (default ID) throw on comparison to prevent accidental identity collisions.
+
+### Result Pattern
+
+```
+Result                          Success/failure without exceptions
+  └─ Result<TValue>             Typed success value
+       │
+       ├─ implicit TValue       Auto-wrap success values
+       └─ implicit Error        Auto-wrap errors
+
+Error(Code, Name, ErrorType)    Value object with HTTP status mapping
+  │
+  ├─ Error.None                 Sentinel for "no error"
+  ├─ Error.NullValue            Sentinel for null arguments
+  └─ Factory methods            BadRequest(), NotFound(), Conflict(), etc.
+
+ErrorType                       Enum mapped to HttpStatusCode values
+```
+
+**Why Result instead of exceptions?** Exceptions are for exceptional situations. Domain validation failures, not-found lookups, and conflict checks are expected outcomes. The Result pattern makes failure explicit in the type signature, forcing callers to handle both paths. Implicit conversions reduce ceremony: `return order;` for success, `return Error.NotFound(...)` for failure.
+
+### Result Extensions
+
+```
+ResultExtensions
+  ├─ Match / MatchAsync         Pattern match on success/failure
+  ├─ Map                        Transform success value (TIn → TOut)
+  ├─ Bind / BindAsync           Chain Result-returning operations
+  ├─ Tap / TapAsync             Side-effect on success (logging, events)
+  └─ OnFailure                  Side-effect on failure (logging, metrics)
+```
+
+These compose into pipelines:
+
+```csharp
+await GetOrder(id)
+    .Map(order => order.ToDto())
+    .Tap(dto => logger.LogInformation("Found order {Id}", dto.Id))
+    .OnFailure(error => logger.LogWarning("Order lookup failed: {Code}", error.Code))
+    .MatchAsync(
+        dto => Results.Ok(dto),
+        error => Results.Problem(error));
+```
+
+### Domain Events
+
+```
+INotification                   Marker interface (no MediatR dependency)
+  └─ IDomainEvent               Domain event marker
+
+Entity<TEntityId>
+  ├─ RaiseDomainEvent()         Buffers events during business logic
+  ├─ GetDomainEvents()          Returns buffered events
+  └─ ClearDomainEvents()        Clears after dispatch
+```
+
+**Why no MediatR dependency?** The domain layer should not depend on infrastructure concerns. `INotification` is a simple marker interface. The infrastructure layer (your mediator of choice) dispatches events collected from entities after persistence.
+
+### Guard Clauses
+
+```
+Guard
+  ├─ CallerArgumentExpression API    Guard.AgainstNullOrEmpty(param)
+  │   (C# 10+ — auto-captures parameter name at compile time)
+  │
+  └─ Expression-based API           Guard.AgainstNullOrEmpty(() => param)
+      (Legacy — extracts name from expression tree at runtime)
+```
+
+Both APIs throw `ArgumentException` subtypes. The `CallerArgumentExpression` API is preferred for new code (zero runtime overhead). The expression-based API exists for backward compatibility.
+
+Guard methods are `internal` with `InternalsVisibleTo` for the test project. This keeps the public API surface clean while allowing thorough testing.
+
+## ASP.NET Core Integration
+
+### Exception Middleware
+
+```
+HTTP Request
+  │
+  ├─ CustomExceptionHandlerMiddleware
+  │     │
+  │     ├─ ValidationException     → 400 Bad Request (grouped errors)
+  │     ├─ NotFoundException       → 404 Not Found
+  │     ├─ ConflictException       → 409 Conflict
+  │     ├─ ForbiddenException      → 403 Forbidden
+  │     ├─ UnauthorizedException   → 401 Unauthorized
+  │     └─ (unknown)               → 500 Internal Server Error
+  │
+  └─ Response: application/problem+json (RFC 7807)
+```
+
+### Module System
+
+```
+IModule
+  ├─ RegisterModule(services)      Register DI services
+  └─ MapEndpoints(app)             Map HTTP endpoints
+
+ModuleExtensions
+  ├─ RegisterModules(services)     Discovers IModule implementations in entry assembly
+  └─ MapEndpoints(app)             Calls MapEndpoints on all discovered modules
+```
+
+The `RegisterModules` overload accepts `Func<Assembly>` for testability — `Assembly.GetEntryAssembly()` returns null under xUnit. This overload is internal (exposed via `InternalsVisibleTo`).
+
+## Validation
+
+```
+FluentValidation.AbstractValidator<T>
+  │
+  └─ ValidationBehavior<TRequest, TResponse>    Pipeline behavior (mediator integration)
+       │
+       └─ throws ValidationException            Caught by middleware → 400
+            │
+            └─ Errors: IReadOnlyDictionary<string, string[]>
+                 (property name → error messages, grouped)
+```
+
+## Component Navigation
+
+**"I want to..."** → Start here:
+
+| Goal | Start at | Key files |
+|------|----------|-----------|
+| Define a domain entity | `Entity<TEntityId>` | `Domain/Abstractions/Entity.cs` |
+| Create a strongly typed ID | `StronglyTypedId<T>` | `Domain/Abstractions/StronglyTypedId.cs` |
+| Return success/failure | `Result<T>` | `Domain/Abstractions/Result.cs`, `Result{TValue}.cs` |
+| Chain Result operations | `ResultExtensions` | `Domain/Extensions/ResultExtensions.cs` |
+| Define error types | `Error` + `ErrorType` | `Domain/Abstractions/Error.cs`, `ErrorType.cs` |
+| Validate parameters | `Guard` | `Domain/Helpers/Guard.cs` |
+| Handle exceptions as HTTP | `CustomExceptionHandlerMiddleware` | `AspNetCore/Middleware/` |
+| Register modules | `ModuleExtensions` | `AspNetCore/Extensions/ModuleExtensions.cs` |
+| Validate with FluentValidation | `ValidationException` | `Validation/ValidationException.cs` |
+| Raise domain events | `Entity.RaiseDomainEvent()` | `Domain/Abstractions/Entity.cs` |
+
+## Directory Structure
+
+```
+Domain/
+  Abstractions/        Entity, Result, Error, ErrorType, INotification, IDomainEvent,
+                       IEntity, IUnitOfWork, StronglyTypedId
+  Helpers/             Guard, GuardCondition
+  Extensions/          StringExtensions, DateTimeExtensions, EnumExtensions,
+                       ResultExtensions, JsonElementExtensions, DecimalArrayExtensions
+  Converters/          DateOnlyConverter, DateOnlyDictionaryConverterFactory
+  Exceptions/          DomainException hierarchy (maps to HTTP status codes)
+  doc/                 Per-component API documentation
+AspNetCore/
+  Middleware/          CustomExceptionHandlerMiddleware
+  Extensions/          ModuleExtensions
+  doc/                 Middleware and module documentation
+Validation/
+  ValidationException  FluentValidation error wrapper
+  doc/                 Validation documentation
+UnitTests/             308 xUnit tests with FluentAssertions
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Boutquin.Domain
 
+> **Language conventions:** `~/.claude/conventions/dotnet-conventions.md`
+
 .NET 10 / C# 14 domain-driven design library. Three NuGet packages published from one solution.
 
 ## Solution Structure

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team through [GitHub Issues](https://github.com/boutquin/Boutquin.Domain/issues). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to Boutquin.Domain
+
+Thank you for considering contributing to Boutquin.Domain! We appreciate your interest and welcome your contributions. Whether it's reporting a bug, proposing a feature, or submitting a pull request, we value your input and strive to make contributing as easy and transparent as possible.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Contributing Code](#contributing-code)
+- [Style Guides](#style-guides)
+  - [Git Commit Messages](#git-commit-messages)
+  - [C# Style Guide](#c-style-guide)
+  - [Documentation Style Guide](#documentation-style-guide)
+- [Pull Request Process](#pull-request-process)
+- [License](#license)
+- [Community](#community)
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior through [GitHub Issues](https://github.com/boutquin/Boutquin.Domain/issues).
+
+## How to Contribute
+
+### Reporting Bugs
+
+If you find a bug in the project, please report it by opening an issue on the [Issues](https://github.com/boutquin/Boutquin.Domain/issues) page. Make sure to include the following information:
+
+- A clear and descriptive title.
+- Steps to reproduce the issue.
+- Expected and actual behavior.
+- Screenshots or code snippets, if applicable.
+- Any other relevant information, such as the operating system and version.
+
+### Suggesting Enhancements
+
+If you have an idea for an enhancement or new feature, we would love to hear about it! Please submit a suggestion by opening an issue on the [Issues](https://github.com/boutquin/Boutquin.Domain/issues) page. Provide the following details:
+
+- A clear and descriptive title.
+- A detailed description of the proposed enhancement.
+- Any relevant use cases or benefits.
+- Any potential downsides or trade-offs.
+
+### Contributing Code
+
+To contribute code to this project, follow these steps:
+
+1. **Fork the repository**: Click the "Fork" button on the top right of the repository page and clone your fork locally.
+    ```bash
+    git clone https://github.com/your-username/Boutquin.Domain.git
+    cd Boutquin.Domain
+    ```
+
+2. **Create a branch**: Create a new branch for your feature or bugfix.
+    ```bash
+    git checkout -b feature-or-bugfix-name
+    ```
+
+3. **Make your changes**: Implement your feature or bugfix, following the style guides outlined below.
+
+4. **Commit your changes**: Write clear and concise commit messages.
+    ```bash
+    git commit -m "Description of the changes made"
+    ```
+
+5. **Push to your fork**: Push your changes to your forked repository.
+    ```bash
+    git push origin feature-or-bugfix-name
+    ```
+
+6. **Open a pull request**: Navigate to the original repository and open a pull request. Provide a clear and descriptive title and description of your changes.
+
+## Style Guides
+
+### Git Commit Messages
+
+- Use the present tense ("Add feature" not "Added feature").
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...").
+- Limit the first line to 72 characters or less.
+- Reference issues and pull requests liberally.
+
+### C# Style Guide
+
+- Follow the [Microsoft C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).
+- Use meaningful names for variables, methods, and classes.
+- Keep methods small and focused.
+- Write comments to explain why code exists, not what it does.
+- Prefer explicit over implicit types.
+
+### Documentation Style Guide
+
+- Use clear and concise language.
+- Follow the [Markdown Guide](https://www.markdownguide.org/basic-syntax/).
+- Use code blocks for code examples.
+- Ensure that documentation is up-to-date with the codebase.
+
+## Pull Request Process
+
+1. **Ensure your code follows the style guides**: Review the style guides above and ensure your code adheres to them.
+
+2. **Run tests**: Ensure that all existing and new tests pass.
+    ```bash
+    dotnet test --collect:"XPlat Code Coverage"
+    ```
+
+3. **Describe your changes**: In your pull request, include a detailed description of your changes, referencing any related issues or pull requests.
+
+4. **Review process**: Your pull request will be reviewed by the maintainers. You may be asked to make changes or provide additional information. Please be responsive to feedback.
+
+5. **Merge process**: Once your pull request is approved, it will be merged by a maintainer. You may delete your branch after the merge.
+
+## License
+
+By contributing to Boutquin.Domain, you agree that your contributions will be licensed under the Apache 2.0 license.
+
+## Community
+
+Join our [GitHub Discussions](https://github.com/boutquin/Boutquin.Domain/discussions) to engage with the community, ask questions, and share ideas.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Domain/Abstractions/Error.cs
+++ b/Domain/Abstractions/Error.cs
@@ -21,6 +21,7 @@ namespace Boutquin.Domain.Abstractions;
 /// </summary>
 /// <param name="Code">A unique error code identifying the type of error.</param>
 /// <param name="Name">A descriptive name for the error.</param>
+/// <param name="ErrorType">The category of the error, mapped to an HTTP status code. Defaults to <see cref="ErrorType.None"/>.</param>
 /// <remarks>
 /// <para>
 /// The Error record is used to encapsulate information about errors that occur within the domain.
@@ -47,7 +48,7 @@ namespace Boutquin.Domain.Abstractions;
 /// }
 /// </code>
 /// </example>
-public record Error(string Code, string Name)
+public record Error(string Code, string Name, ErrorType ErrorType = default)
 {
     /// <summary>
     /// Represents no error.
@@ -64,4 +65,25 @@ public record Error(string Code, string Name)
     /// This static member can be used when a null value is provided where it is not allowed.
     /// </remarks>
     public static readonly Error NullValue = new("Error.NullValue", "Null value was provided");
+
+    /// <summary>Creates a <see cref="ErrorType.BadRequest"/> (400) error.</summary>
+    public static Error BadRequest(string code, string name) => new(code, name, ErrorType.BadRequest);
+
+    /// <summary>Creates a <see cref="ErrorType.NotFound"/> (404) error.</summary>
+    public static Error NotFound(string code, string name) => new(code, name, ErrorType.NotFound);
+
+    /// <summary>Creates a <see cref="ErrorType.Conflict"/> (409) error.</summary>
+    public static Error Conflict(string code, string name) => new(code, name, ErrorType.Conflict);
+
+    /// <summary>Creates a <see cref="ErrorType.Unauthorized"/> (401) error.</summary>
+    public static Error Unauthorized(string code, string name) => new(code, name, ErrorType.Unauthorized);
+
+    /// <summary>Creates a <see cref="ErrorType.Forbidden"/> (403) error.</summary>
+    public static Error Forbidden(string code, string name) => new(code, name, ErrorType.Forbidden);
+
+    /// <summary>Creates a <see cref="ErrorType.RequestTimeout"/> (408) error.</summary>
+    public static Error RequestTimeout(string code, string name) => new(code, name, ErrorType.RequestTimeout);
+
+    /// <summary>Creates a <see cref="ErrorType.InternalServerError"/> (500) error.</summary>
+    public static Error InternalServerError(string code, string name) => new(code, name, ErrorType.InternalServerError);
 }

--- a/Domain/Abstractions/ErrorType.cs
+++ b/Domain/Abstractions/ErrorType.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2024-2026 Pierre G. Boutquin. All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License").
+//   You may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Net;
+
+namespace Boutquin.Domain.Abstractions;
+
+/// <summary>
+/// Represents the type of an error, mapped to HTTP status codes for interoperability
+/// with web APIs and mediator pipelines.
+/// </summary>
+/// <remarks>
+/// Each value corresponds to an <see cref="HttpStatusCode"/> to enable consistent
+/// error-to-HTTP-response mapping across application layers.
+/// The <see cref="None"/> value (0) is used for backward compatibility with <see cref="Error.None"/>.
+/// </remarks>
+public enum ErrorType
+{
+    /// <summary>No error type specified. Used for backward compatibility with <see cref="Error.None"/>.</summary>
+    None = 0,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.BadRequest"/> (400).</summary>
+    BadRequest = (int)HttpStatusCode.BadRequest,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.Unauthorized"/> (401).</summary>
+    Unauthorized = (int)HttpStatusCode.Unauthorized,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.PaymentRequired"/> (402).</summary>
+    PaymentRequired = (int)HttpStatusCode.PaymentRequired,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.Forbidden"/> (403).</summary>
+    Forbidden = (int)HttpStatusCode.Forbidden,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.NotFound"/> (404).</summary>
+    NotFound = (int)HttpStatusCode.NotFound,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.MethodNotAllowed"/> (405).</summary>
+    MethodNotAllowed = (int)HttpStatusCode.MethodNotAllowed,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.NotAcceptable"/> (406).</summary>
+    NotAcceptable = (int)HttpStatusCode.NotAcceptable,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.ProxyAuthenticationRequired"/> (407).</summary>
+    ProxyAuthenticationRequired = (int)HttpStatusCode.ProxyAuthenticationRequired,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.RequestTimeout"/> (408).</summary>
+    RequestTimeout = (int)HttpStatusCode.RequestTimeout,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.Conflict"/> (409).</summary>
+    Conflict = (int)HttpStatusCode.Conflict,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.Gone"/> (410).</summary>
+    Gone = (int)HttpStatusCode.Gone,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.LengthRequired"/> (411).</summary>
+    LengthRequired = (int)HttpStatusCode.LengthRequired,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.PreconditionFailed"/> (412).</summary>
+    PreconditionFailed = (int)HttpStatusCode.PreconditionFailed,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.RequestEntityTooLarge"/> (413).</summary>
+    RequestEntityTooLarge = (int)HttpStatusCode.RequestEntityTooLarge,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.RequestUriTooLong"/> (414).</summary>
+    RequestUriTooLong = (int)HttpStatusCode.RequestUriTooLong,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.UnsupportedMediaType"/> (415).</summary>
+    UnsupportedMediaType = (int)HttpStatusCode.UnsupportedMediaType,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.RequestedRangeNotSatisfiable"/> (416).</summary>
+    RequestedRangeNotSatisfiable = (int)HttpStatusCode.RequestedRangeNotSatisfiable,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.ExpectationFailed"/> (417).</summary>
+    ExpectationFailed = (int)HttpStatusCode.ExpectationFailed,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.TooManyRequests"/> (429).</summary>
+    TooManyRequests = (int)HttpStatusCode.TooManyRequests,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.RequestHeaderFieldsTooLarge"/> (431).</summary>
+    RequestHeaderFieldsTooLarge = (int)HttpStatusCode.RequestHeaderFieldsTooLarge,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.InternalServerError"/> (500).</summary>
+    InternalServerError = (int)HttpStatusCode.InternalServerError,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.NotImplemented"/> (501).</summary>
+    NotImplemented = (int)HttpStatusCode.NotImplemented,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.BadGateway"/> (502).</summary>
+    BadGateway = (int)HttpStatusCode.BadGateway,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.ServiceUnavailable"/> (503).</summary>
+    ServiceUnavailable = (int)HttpStatusCode.ServiceUnavailable,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.GatewayTimeout"/> (504).</summary>
+    GatewayTimeout = (int)HttpStatusCode.GatewayTimeout,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.HttpVersionNotSupported"/> (505).</summary>
+    HttpVersionNotSupported = (int)HttpStatusCode.HttpVersionNotSupported,
+
+    /// <summary>Maps to <see cref="HttpStatusCode.InsufficientStorage"/> (507).</summary>
+    InsufficientStorage = (int)HttpStatusCode.InsufficientStorage,
+}

--- a/Domain/Abstractions/IDomainEvent.cs
+++ b/Domain/Abstractions/IDomainEvent.cs
@@ -16,21 +16,19 @@
 
 namespace Boutquin.Domain.Abstractions;
 
-using MediatR;
-
 /// <summary>
 /// Represents a domain event within the system.
 /// </summary>
 /// <remarks>
 /// <para>
 /// A domain event is an event that is significant within the domain of the application.
-/// Implementing this interface allows an object to be dispatched by MediatR as a notification,
+/// Implementing this interface allows an object to be dispatched by a mediator as a notification,
 /// enabling a decoupled, event-driven architecture.
 /// </para>
 /// <para>
 /// In a domain-driven design context, domain events are used to model important occurrences within the domain.
 /// These events are typically things that have happened in the past (e.g., OrderPlaced, ItemShipped, etc.).
-/// By implementing the <see cref="INotification"/> interface from MediatR, domain events can be dispatched
+/// By implementing the <see cref="INotification"/> interface, domain events can be dispatched
 /// to relevant handlers which can then perform specific actions in response to the event.
 /// </para>
 /// <para>
@@ -42,11 +40,6 @@ using MediatR;
 /// The interface itself does not define any members; it serves as a marker interface to signify that
 /// a class is a domain event. Implementors of this interface should contain properties that provide
 /// details about the event itself.
-/// </para>
-/// <para>
-/// <strong>Note:</strong> This interface extends MediatR's <see cref="INotification"/> to enable
-/// dispatching via MediatR. If you prefer to avoid the MediatR dependency in your domain layer,
-/// consider defining your own marker interface and adapting at the infrastructure level.
 /// </para>
 /// </remarks>
 /// <example>

--- a/Domain/Abstractions/INotification.cs
+++ b/Domain/Abstractions/INotification.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2024-2026 Pierre G. Boutquin. All rights reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License").
+//   You may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+namespace Boutquin.Domain.Abstractions;
+
+/// <summary>
+/// Represents a notification message or event that can be dispatched to subscribers.
+/// </summary>
+/// <remarks>This interface is a marker for notification types in a publish-subscribe or
+/// mediator pattern. Implementing types define the specific details of the notification.</remarks>
+public interface INotification;

--- a/Domain/Abstractions/Result.cs
+++ b/Domain/Abstractions/Result.cs
@@ -193,4 +193,19 @@ public class Result
     /// </example>
     public static Result<TValue> Create<TValue>(TValue? value) =>
         value is not null ? Success(value) : Failure<TValue>(Error.NullValue);
+
+    /// <summary>
+    /// Creates a failure result representing a cancelled operation.
+    /// </summary>
+    /// <param name="code">The error code for the cancellation. Defaults to "Error.Cancellation".</param>
+    /// <param name="name">The error description. Defaults to "The request was cancelled.".</param>
+    /// <returns>A failed result with a <see cref="ErrorType.RequestTimeout"/> error.</returns>
+    public static Result Cancelled(string code = "Error.Cancellation", string name = "The request was cancelled.") =>
+        Failure(Error.RequestTimeout(code, name));
+
+    /// <summary>
+    /// Implicitly converts an <see cref="Error"/> to a failed <see cref="Result"/>.
+    /// </summary>
+    /// <param name="error">The error to convert.</param>
+    public static implicit operator Result(Error error) => new(false, error);
 }

--- a/Domain/Abstractions/Result{TValue}.cs
+++ b/Domain/Abstractions/Result{TValue}.cs
@@ -101,4 +101,10 @@ public sealed class Result<TValue> : Result
     /// This conversion simplifies returning a successful result from methods.
     /// </remarks>
     public static implicit operator Result<TValue>(TValue? value) => Create(value);
+
+    /// <summary>
+    /// Implicitly converts an <see cref="Error"/> to a failed <see cref="Result{TValue}"/>.
+    /// </summary>
+    /// <param name="error">The error to convert.</param>
+    public static implicit operator Result<TValue>(Error error) => new(default, false, error);
 }

--- a/Domain/Boutquin.Domain.csproj
+++ b/Domain/Boutquin.Domain.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
     <PackageReference Include="MinVer" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Domain/Extensions/ResultExtensions.cs
+++ b/Domain/Extensions/ResultExtensions.cs
@@ -17,6 +17,7 @@
 namespace Boutquin.Domain.Extensions;
 
 using System;
+using System.Threading.Tasks;
 using Abstractions;
 
 /// <summary>
@@ -70,4 +71,168 @@ public static class ResultExtensions
         Func<TValue, TResult> onSuccess,
         Func<Error, TResult> onFailure) =>
         result.IsSuccess ? onSuccess(result.Value) : onFailure(result.Error);
+
+    /// <summary>
+    /// Asynchronously evaluates a Result and returns a value based on success or failure.
+    /// </summary>
+    /// <typeparam name="T">The type of the return value.</typeparam>
+    /// <param name="resultTask">The asynchronous Result to evaluate.</param>
+    /// <param name="onSuccess">The function to execute if the Result indicates success.</param>
+    /// <param name="onFailure">The function to execute if the Result indicates failure.</param>
+    /// <returns>The return value of either the onSuccess or onFailure function.</returns>
+    public static async ValueTask<T> MatchAsync<T>(
+        this ValueTask<Result> resultTask,
+        Func<Task<T>> onSuccess,
+        Func<Error, Task<T>> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? await onSuccess().ConfigureAwait(false)
+            : await onFailure(result.Error).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously evaluates a Result{TValue} and returns a value based on success or failure.
+    /// </summary>
+    /// <typeparam name="T">The type of the return value.</typeparam>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The asynchronous Result to evaluate.</param>
+    /// <param name="onSuccess">The function to execute if the Result indicates success, receiving the value.</param>
+    /// <param name="onFailure">The function to execute if the Result indicates failure.</param>
+    /// <returns>The return value of either the onSuccess or onFailure function.</returns>
+    public static async ValueTask<T> MatchAsync<T, TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Task<T>> onSuccess,
+        Func<Error, Task<T>> onFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onFailure);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? await onSuccess(result.Value).ConfigureAwait(false)
+            : await onFailure(result.Error).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Transforms the value of a successful Result into a new Result with a different value type.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the input value.</typeparam>
+    /// <typeparam name="TOut">The type of the output value.</typeparam>
+    /// <param name="result">The Result to transform.</param>
+    /// <param name="func">The transformation function to apply to the value.</param>
+    /// <returns>A new Result containing the transformed value, or the original error on failure.</returns>
+    public static Result<TOut> Map<TIn, TOut>(this Result<TIn> result, Func<TIn, TOut> func)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess
+            ? Result.Success(func(result.Value))
+            : Result.Failure<TOut>(result.Error);
+    }
+
+    /// <summary>
+    /// Chains a Result-returning operation onto a successful Result.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the input value.</typeparam>
+    /// <typeparam name="TOut">The type of the output value.</typeparam>
+    /// <param name="result">The Result to bind.</param>
+    /// <param name="func">The function that returns a new Result.</param>
+    /// <returns>The Result of the chained operation, or the original error on failure.</returns>
+    public static Result<TOut> Bind<TIn, TOut>(this Result<TIn> result, Func<TIn, Result<TOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess
+            ? func(result.Value)
+            : Result.Failure<TOut>(result.Error);
+    }
+
+    /// <summary>
+    /// Asynchronously chains a Result-returning operation onto a successful Result.
+    /// </summary>
+    /// <typeparam name="TIn">The type of the input value.</typeparam>
+    /// <typeparam name="TOut">The type of the output value.</typeparam>
+    /// <param name="resultTask">The asynchronous Result to bind.</param>
+    /// <param name="func">The async function that returns a new Result.</param>
+    /// <returns>The Result of the chained operation, or the original error on failure.</returns>
+    public static async ValueTask<Result<TOut>> BindAsync<TIn, TOut>(
+        this Task<Result<TIn>> resultTask,
+        Func<TIn, Task<Result<TOut>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(resultTask);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.IsSuccess
+            ? await func(result.Value).ConfigureAwait(false)
+            : Result.Failure<TOut>(result.Error);
+    }
+
+    /// <summary>
+    /// Executes a side-effect action on a successful Result without altering the result.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The Result to tap.</param>
+    /// <param name="action">The action to execute on the value if the Result is successful.</param>
+    /// <returns>The original Result, unchanged.</returns>
+    public static Result<T> Tap<T>(this Result<T> result, Action<T> action)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsSuccess)
+        {
+            action(result.Value);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Asynchronously executes a side-effect action on a successful Result.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The asynchronous Result to tap.</param>
+    /// <param name="action">The async action to execute on the value if the Result is successful.</param>
+    /// <returns>The original Result, unchanged.</returns>
+    public static async ValueTask<Result<T>> TapAsync<T>(
+        this ValueTask<Result<T>> resultTask,
+        Func<T, Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await action(result.Value).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a side-effect action on a failed Result without altering the result.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The Result to inspect.</param>
+    /// <param name="action">The action to execute on the error if the Result is a failure.</param>
+    /// <returns>The original Result, unchanged.</returns>
+    public static Result<T> OnFailure<T>(this Result<T> result, Action<Error> action)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (!result.IsSuccess)
+        {
+            action(result.Error);
+        }
+
+        return result;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The building blocks for Domain-Driven Design:
 - **[Result / Result&lt;TValue&gt;](Domain/doc/Result.md)** — Functional error handling — return success/failure instead of throwing exceptions.
 - **[Error](Domain/doc/Result.md)** — Immutable record representing a domain error with code and name.
 - **IEntity** — Interface for entities that generate domain events.
-- **IDomainEvent** — Marker interface extending MediatR's `INotification` for domain events.
+- **IDomainEvent** — Marker interface for domain events (implements `INotification`).
 - **IUnitOfWork** — Defines the persistence boundary (`SaveChangesAsync`).
 
 ### Helpers
@@ -98,9 +98,13 @@ throw new NotFoundException("Order 42 was not found.");
 // -> 404 ProblemDetails JSON response
 ```
 
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for how the components fit together — layers, interface hierarchy, data flow, and component navigation.
+
 ## Contributing
 
-If you'd like to contribute, please feel free to submit a pull request or open an issue with your suggestions or improvements.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting enhancements, and submitting pull requests. This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Remove `MediatR.Contracts` dependency — replaced with local `INotification` marker interface
- Add `ErrorType` enum mapped to `HttpStatusCode` for error-to-HTTP mapping
- Add factory methods on `Error` (BadRequest, NotFound, Conflict, etc.) and implicit `Error → Result` conversions
- Add Result extensions: `Map`, `Bind`, `BindAsync`, `Tap`, `TapAsync`, `OnFailure`, `MatchAsync`
- Enable `TreatWarningsAsErrors` and coverage artifact upload in CI
- Add ARCHITECTURE.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 308 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)